### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -83,7 +83,7 @@
   }
   {
     'comment': 'source: ruby bundle'
-    'match': '\\b(0[xX]\\h(?>_?\\h)*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+)\\b'
+    'match': '\\b(0[xX][0-9A-Fa-f](?>_?[0-9A-Fa-f])*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+)\\b'
     'name': 'constant.numeric.supercollider'
   }
 ]


### PR DESCRIPTION
Depending on the regular expression engine used, `\h` does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.